### PR TITLE
feat: make the poller poll multiple pricefeeds

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ class TomlError(Exception):
 def load_config(filename):
   config = toml.load(filename)
   # Check the necessary fields are provided in the toml
-  if  config.get('contract') is None or config['contract'].get('pricefeed') is None or config['contract'].get('wrb') is None:
+  if  config.get('contract') is None or config['contract'].get('pricefeeds') is None or config['contract'].get('wrb') is None:
     raise TomlError("Please specify pricefeed and wrb as \n[contract]\npricefeed=0xaaaa\nwrb=0xbbbb")
   elif  config.get('account') is None or config['account'].get('address') is None:
     raise TomlError("Please specify account as \n[account]\naddress=0xaaaa")

--- a/contract.py
+++ b/contract.py
@@ -12,11 +12,10 @@ def wrb(w3, config_file):
 
 # Return the pricefeed contract, given a Ethereum address from "config.toml"
 def pricefeed(w3, config_file):
-  contract_address = config_file["contract"]["pricefeed"]
-    # ABI generated using
-    # https://remix.ethereum.org
+  contract_addresses = config_file["contract"]["pricefeeds"]
+  # ABI generated using
+  # https://remix.ethereum.org
   with open("pricefeed_abi.json") as json_file:
     contract_abi = json.load(json_file)
-    contract = w3.eth.contract(contract_address, abi=contract_abi)
-    return contract
+    return [w3.eth.contract(address, abi=contract_abi) for address in contract_addresses]
 

--- a/pricefeed_abi.json
+++ b/pricefeed_abi.json
@@ -1,118 +1,168 @@
 [
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_wrb",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "constructor"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "name": "priceUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "name": "resultError",
-      "type": "event"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "bitcoinPrice",
-      "outputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "lastRequestId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "pending",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "request",
-      "outputs": [
-        {
-          "internalType": "contract Request",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [],
-      "name": "requestUpdate",
-      "outputs": [],
-      "payable": true,
-      "stateMutability": "payable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [],
-      "name": "completeUpdate",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_wrb",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "name": "priceUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "resultError",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BTCUSD3ID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "lastPrice",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "lastRequestId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "pending",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "request",
+    "outputs": [
+      {
+        "internalType": "contract Request",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "timestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "requestUpdate",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function",
+    "payable": true
+  },
+  {
+    "inputs": [],
+    "name": "completeUpdate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "valueFor",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  }
 ]

--- a/tomls/goerli.toml
+++ b/tomls/goerli.toml
@@ -1,7 +1,7 @@
 [contract]
 # The contracts the poller needs to interact with
 wrb = "0xFBd67d672C12B130b61320026E5B681f9040bCd3"
-pricefeed = "0x31EcDb4b4514f134a602F44415E89ffC8B8193e6"
+pricefeeds = ["0x31EcDb4b4514f134a602F44415E89ffC8B8193e6"]
 
 [account]
 # The ethereum address which will create the transactions

--- a/tomls/rinkeby.toml
+++ b/tomls/rinkeby.toml
@@ -1,7 +1,7 @@
 [contract]
 # The contracts the poller needs to interact with
 wrb = "0x996Be500EBF09537EDde024f70fFdFA55089E939"
-pricefeed = "0xE046EC0088c9330Ecb4A90D4F2c29cA0Bc31706d"
+pricefeeds = ["0xE50372951AE5B4EF099076E9091CF1D2AF00d81E", "0xeFd4bbe486bBD5248D842337B88151B2Dd5534aA"]
 
 [account]
 # The ethereum address which will create the transactions


### PR DESCRIPTION
This PR adds support for specifying mutliple pricefeeds in the TOML configuration file, and as long as they share the same ABI the poller will interact with all of them